### PR TITLE
Install stubs for mypy types

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ pytest>=5.2.0
 pytest-cov>=2.6.1
 pre-commit>=2.7.1
 flake8==3.8.4
+types-pytz>=0.1.0
+types-deprecated>=0.1.1


### PR DESCRIPTION
`mypy` will complain if these types packages are not installed.
```
mffpy/reader.py:18: error: Library stubs not installed for "deprecated" (or incompatible with Python 3.6)
mffpy/reader.py:18: note: Hint: "python3 -m pip install types-Deprecated"
```
I am not sure why we didn't see these errors in the GH workflow before, but this appears to fix them.